### PR TITLE
Fixed a crash caused by a change in musicmetadata module

### DIFF
--- a/lib/id3Parser.js
+++ b/lib/id3Parser.js
@@ -19,14 +19,7 @@ var id3Parser = function(attributes, path, callback) {
 
   attributes = attributes || {};
 
-  var parser = mm(stream);
-  var tags = null;
-
-  parser.on('metadata', function(result) {
-    tags = result;
-  });
-
-  parser.on('done', function(error) {
+  mm(stream, function(error, tags) {
     try {
       stream.destroy();
     } catch (x) {
@@ -64,15 +57,7 @@ var id3Parser = function(attributes, path, callback) {
 function getPicture(path, pictureIndex, callback) {
 
   var stream = fs.createReadStream(path);
-  var parser = mm(stream);
-  var tags = null;
-
-  parser.on('metadata', function(result) {
-    tags = result;
-  });
-
-  parser.on('done', function(error) {
-    // console.log("Tags=", tags);
+  mm(stream, function(error, tags) {
     try {
       stream.destroy();
     } catch (x) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jstoxml": "0.2",
     "node-uuid": "1.4",
     "xmldoc": "0.1.2",
-    "musicmetadata": "latest",
+    "musicmetadata": "1.0.0",
     "mime": "1.2",
     "send": "0.3",
     "underscore": "1.6",


### PR DESCRIPTION
The musicmetadata module now uses callbacks instead of an event emitter. This has created an issue where the upnpserver will crash when trying to parse metadata with the error `TypeError: Cannot read property 'hasOwnProperty' of undefined` This patch fixes the issue by updating the event emitter code to use callbacks.

I've also added a version number to package.json to prevent api changes in musicmetadata causing issues with upnpserver.