### PR TITLE
Fixed scpd.xml errors reported in Device Spy

### DIFF
--- a/lib/avTransportService.js
+++ b/lib/avTransportService.js
@@ -261,6 +261,8 @@ var  AVTransportService = function(configuration) {
       [], null, 2);
   this.addType("PossibleRecordQualityModes", "string", "NOT_IMPLEMENTED",
       [], null, 2);
+  this.addType("CurrentMediaCategory", "string", "NO_MEDIA",
+    ["NO_MEDIA", "TRACK_AWARE", "TRACK_UNAWARE"], null, 2);
   this.addType("NumberOfTracks", "ui4", 0, [],null, 2);
   this.addType("CurrentTrack", "ui4", 0, [],null, 2);
   this.addType("CurrentTrackDuration", "string", "0", [],null, 2);

--- a/lib/renderingControlService.js
+++ b/lib/renderingControlService.js
@@ -78,16 +78,16 @@ var  RenderingControlService = function(configuration) {
     },{
       name:'PresetName',
       type:'A_ARG_TYPE_PresetName'
-    },[]]);
+    }],[]);
 
   this.addType("A_ARG_TYPE_InstanceID", "ui4", configuration.InstanceID || 0);
   this.addType("LastChange", "string", "", [], {"rcs-event":"urn:schemas-upnp-org:metadata-1-0/RCS"}, true, 0.2);
-  this.addType("A_ARG_TYPE_Channel", "string", "Master", ["Master"])
+  this.addType("A_ARG_TYPE_Channel", "string", "Master", ["Master"]);
   this.addType("A_ARG_TYPE_PresetName", "string", "FactoryDefaults",
-      ["FactoryDefaults"])
-  this.addType("Volume", "ui2", 50)
-  this.addType("Mute", "boolean", 0)
-  this.addType("PresetNameList", "string", "FactoryDefaults")
+      ["FactoryDefaults", "InstallationDefaults"]);
+  this.addType("Volume", "ui2", 50);
+  this.addType("Mute", "boolean", 0);
+  this.addType("PresetNameList", "string", "FactoryDefaults");
   return this;
 }
 
@@ -108,7 +108,7 @@ RenderingControlService.prototype.processSoap_SetVolume = function(request,
 
       // playlist url or single item
       this.emit("volume", volume, function(){
-          callback());
+          callback();
       }.bind(this));
 
 }


### PR DESCRIPTION
To test make avTransport the first service in servicesList. Without the change Device Spy will not display the device. Debug log in device spy shows that the spcd.xml isnt correct or the param type is not defined.  