### PR TITLE
Replaced musicmetadata with music-metadata

### DIFF
--- a/lib/contentHandlers/audio_musicmetadata.js
+++ b/lib/contentHandlers/audio_musicmetadata.js
@@ -3,7 +3,7 @@
 
 const crypto = require('crypto');
 
-const mm = require('musicmetadata');
+const mm = require('music-metadata');
 const Mime = require('mime');
 
 const debug = require('debug')('upnpserver:contentHandlers:Musicmetadata');
@@ -13,249 +13,205 @@ const ContentHandler = require('./contentHandler');
 
 class Audio_MusicMetadata extends ContentHandler {
 
-	/**
-	 *
-	 */
-	get name() {
-		return "musicMetadata";
-	}
+  /**
+   *
+   */
+  get name () {
+    return "musicMetadata";
+  }
 
-	/**
-	 *
-	 */
-	prepareMetas(contentInfos, context, callback) {
+  /**
+   *
+   */
+  prepareMetas (contentInfos, context, callback) {
 
-		debug("Prepare", contentInfos);
+    debug("Prepare", contentInfos);
 
-		var contentURL = contentInfos.contentURL;
+    const contentURL = contentInfos.contentURL;
 
-		contentURL.createReadStream(null, null, (error, stream) => {
-			if (error) {
-				return callback(error);
-			}
+    let parsing = true;
 
-			var parsing = true;
+    debug("Start musicMetadata contentURL=", contentURL);
 
-			try {
-				debug("Start musicMetadata contentURL=", contentURL);
-				mm(stream, {
-					// duration : true
-					// fileSize : stats.size
+    mm.parseFile(contentURL.path, {
+      // duration : true
+      // fileSize : stats.size
+    }).then((tags) => {
 
-				}, (error, tags) => {
+      parsing = false;
 
-					try {
-						stream.destroy();
-					} catch (x) {
-						logger.error("Can not close stream", x);
-					}
+      debug("Parsed musicMetadata path=", contentURL.path, "tags=", tags);
 
-					parsing = false;
+      if (!tags) {
+        logger.error("MM does not support: " + contentURL.path);
+        return callback();
+      }
 
-					if (error) {
-						logger.error("MM can not parse tags of contentURL=", contentURL, " error=",
-							error);
-						return callback();
-					}
+      const metas = {};
 
-					debug("Parsed musicMetadata contentURL=", contentURL, "tags=", tags);
+      ['title', 'album', 'duration'].forEach((n) => {
+        if (tags[n]) {
+          metas[n] = tags[n];
+        }
+      });
 
-					if (!tags) {
-						logger.error("MM does not support: " + contentURL);
-						return callback();
-					}
+      metas.albumArtists = tags.common.albumartist ? [tags.common.albumartist] : tags.common.artists;
+      metas.artists = tags.common.artists ? tags.common.artists : [tags.common.albumartist];
+      metas.genres = tags.common.genre;
 
-					var metas = {};
+      if (tags.year) {
+        metas.year = tags.year && parseInt(tags.year, 10);
+      }
 
-					['title', 'album', 'duration'].forEach((n) => {
-						if (tags[n]) {
-							metas[n] = tags[n];
-						}
-					});
+      var track = tags.track;
+      if (track) {
+        if (typeof (track.no) === "number" && track.no) {
+          metas.originalTrackNumber = track.no;
 
-					metas.albumArtists = normalize(tags.albumartist);
-					metas.artists = normalize(tags.artist);
-					metas.genres = normalize(tags.genre);
+          if (typeof (track.of) === "number" && track.of) {
+            metas.trackOf = track.of;
+          }
+        }
+      }
 
-					if (tags.year) {
-						metas.year = tags.year && parseInt(tags.year, 10);
-					}
+      var disk = tags.disk;
+      if (disk) {
+        if (typeof (disk.no) === "number" && disk.no) {
+          metas.originalDiscNumber = disk.no;
 
-					var track = tags.track;
-					if (track) {
-						if (typeof (track.no) === "number" && track.no) {
-							metas.originalTrackNumber = track.no;
+          if (typeof (disk.of) === "number" && disk.of) {
+            metas.diskOf = disk.of;
+          }
+        }
+      }
 
-							if (typeof (track.of) === "number" && track.of) {
-								metas.trackOf = track.of;
-							}
-						}
-					}
+      if (tags.picture) {
+        var as = [];
+        var res = [{}];
 
-					var disk = tags.disk;
-					if (disk) {
-						if (typeof (disk.no) === "number" && disk.no) {
-							metas.originalDiscNumber = disk.no;
+        var index = 0;
+        tags.picture.forEach((picture) => {
+          var mimeType = Mime.lookup(picture.format);
 
-							if (typeof (disk.of) === "number" && disk.of) {
-								metas.diskOf = disk.of;
-							}
-						}
-					}
+          var key = index++;
 
-					if (tags.picture) {
-						var as = [];
-						var res = [{}];
+          if (!mimeType) {
+            return;
+          }
 
-						var index = 0;
-						tags.picture.forEach((picture) => {
-							var mimeType = Mime.lookup(picture.format);
+          if (!mimeType.indexOf("image/")) {
 
-							var key = index++;
+            var hash = computeHash(picture.data);
 
-							if (!mimeType) {
-								return;
-							}
+            as.push({
+              contentHandlerKey: this.name,
+              mimeType: mimeType,
+              size: picture.data.length,
+              hash: hash,
+              key: key
+            });
+            return;
+          }
 
-							if (!mimeType.indexOf("image/")) {
+          res.push({
+            contentHandlerKey: this.name,
+            mimeType: mimeType,
+            size: picture.data.length,
+            key: key
+          });
 
-								var hash = computeHash(picture.data);
+        });
 
-								as.push({
-									contentHandlerKey: this.name,
-									mimeType: mimeType,
-									size: picture.data.length,
-									hash: hash,
-									key: key
-								});
-								return;
-							}
+        if (as.length) {
+          metas.albumArts = as;
+        }
+        if (res.length > 1) {
+          metas.res = res;
+        }
+      }
 
-							res.push({
-								contentHandlerKey: this.name,
-								mimeType: mimeType,
-								size: picture.data.length,
-								key: key
-							});
+      callback(null, metas);
+    }).catch((err) => {
+      logger.error("MM can not parse tags of contentURL=", contentURL, " error=",
+        err);
+      return callback();
+    });
+  }
 
-						});
+  /**
+   *
+   */
+  processRequest (node, request, response, path, parameters, callback) {
 
-						if (as.length) {
-							metas.albumArts = as;
-						}
-						if (res.length > 1) {
-							metas.res = res;
-						}
-					}
+    var albumArtKey = parseInt(parameters[0], 10);
+    if (isNaN(albumArtKey) || albumArtKey < 0) {
+      let error = new Error("Invalid albumArtKey parameter (" + parameters + ")");
+      error.node = node;
+      error.request = request;
 
-					callback(null, metas);
-				});
-			} catch (x) {
-				if (parsing) {
-					console.error("Catch ", x, x.stack);
-					try {
-						stream.destroy();
+      return callback(error, false);
+    }
 
-					} catch (x) {
-						logger.error("Can not close stream", x);
-					}
+    var contentURL = node.contentURL;
+    // console.log("Get stream of " + node, node.attributes);
 
-					logger.error("MM: Parsing exception contentURL=" + contentURL, x);
-					return callback();
-				}
-				logger.error("Catch ", x, x.stack);
+    this._getPicture(node, contentURL, albumArtKey, (error, picture) => {
 
-				throw x;
-			}
-		});
-	}
+      if (!picture.format || !picture.data) {
+        let error = new Error('Invalid picture for node #' + node.id + ' key=' + albumArtKey);
+        error.node = node;
+        error.request = request;
 
-	/**
-	 *
-	 */
-	processRequest(node, request, response, path, parameters, callback) {
+        return callback(error, false);
+      }
 
-		var albumArtKey = parseInt(parameters[0], 10);
-		if (isNaN(albumArtKey) || albumArtKey < 0) {
-			let error = new Error("Invalid albumArtKey parameter (" + parameters + ")");
-			error.node = node;
-			error.request = request;
+      response.setHeader("Content-Type", picture.format);
+      response.setHeader("Content-Size", picture.data.length);
 
-			return callback(error, false);
-		}
+      response.end(picture.data, () => callback(null, true));
+    });
+  }
 
-		var contentURL = node.contentURL;
-		// console.log("Get stream of " + node, node.attributes);
+  _getPicture (node, contentURL, pictureIndex, callback) {
 
-		this._getPicture(node, contentURL, albumArtKey, (error, picture) => {
+    contentURL.createReadStream(null, null, (error, stream) => {
+      if (error) {
+        return callback(error);
+      }
 
-			if (!picture.format || !picture.data) {
-				let error = new Error('Invalid picture for node #' + node.id + ' key=' + albumArtKey);
-				error.node = node;
-				error.request = request;
+      mm(stream, (error, tags) => {
+        try {
+          stream.destroy();
+        } catch (x) {
+          logger.error("Can not close stream", x);
+        }
 
-				return callback(error, false);
-			}
+        if (error) {
+          logger.error("Can not parse ID3 of " + contentURL, error);
+          return callback("Can not parse ID3");
+        }
 
-			response.setHeader("Content-Type", picture.format);
-			response.setHeader("Content-Size", picture.data.length);
+        if (!tags || !tags.picture || tags.picture.length <= pictureIndex) {
+          let error = new Error('Picture #' + pictureIndex + ' not found');
 
-			response.end(picture.data, () => callback(null, true));
-		});
-	}
+          logger.error(error);
+          return callback(error);
+        }
 
-	_getPicture(node, contentURL, pictureIndex, callback) {
+        var picture = tags.picture[pictureIndex];
+        tags = null;
 
-		contentURL.createReadStream(null, null, (error, stream) => {
-			if (error) {
-				return callback(error);
-			}
-
-			mm(stream, (error, tags) => {
-				try {
-					stream.destroy();
-				} catch (x) {
-					logger.error("Can not close stream", x);
-				}
-
-				if (error) {
-					logger.error("Can not parse ID3 of " + contentURL, error);
-					return callback("Can not parse ID3");
-				}
-
-				if (!tags || !tags.picture || tags.picture.length <= pictureIndex) {
-					let error = new Error('Picture #' + pictureIndex + ' not found');
-
-					logger.error(error);
-					return callback(error);
-				}
-
-				var picture = tags.picture[pictureIndex];
-				tags = null;
-
-				callback(null, picture);
-			});
-		});
-	}
+        callback(null, picture);
+      });
+    });
+  }
 }
 
-function normalize(strs) {
-	var r = [];
-	if (!strs || !strs.length) {
-		return undefined;
-	}
-	strs.forEach((str) => str.split(',').forEach(
-		(tok) =>
-			r.push(tok.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()).trim())
-	));
-	return r;
-}
+function computeHash (buffer) {
+  var shasum = crypto.createHash('sha1');
+  shasum.update(buffer);
 
-function computeHash(buffer) {
-	var shasum = crypto.createHash('sha1');
-	shasum.update(buffer);
-
-	return shasum.digest('hex');
+  return shasum.digest('hex');
 }
 
 module.exports = Audio_MusicMetadata;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "mime": "1.2",
     "mkdirp": "latest",
     "moviedb": "^0.2.2",
-    "musicmetadata": "^2.0.2",
+    "music-metadata": "^0.7.14",
     "node-ssdp": "^2.7.0",
     "omdb-client": "^1.0.6",
     "range-parser": "^1.0.3",


### PR DESCRIPTION
- This module is alive and provides support
- Faster file parsing, using direct file access it can jump though a file rather then read everything.
- Support more audio formats, metadata standards and tags.